### PR TITLE
修复非法cookie输入的时候的报错

### DIFF
--- a/plugins/cookies.py
+++ b/plugins/cookies.py
@@ -139,12 +139,15 @@ class Cookies(BasePlugins):
         except InvalidCookies:
             await update.message.reply_text("Cookies已经过期，请检查是否正确", reply_markup=ReplyKeyboardRemove())
             return ConversationHandler.END
-        except AttributeError:
-            await update.message.reply_text("Cookies错误，请检查是否正确", reply_markup=ReplyKeyboardRemove())
-            return ConversationHandler.END
         except GenshinException as error:
             await update.message.reply_text(f"获取账号信息发生错误，错误信息为 {str(error)}，请检查Cookie或者账号是否正常",
                                             reply_markup=ReplyKeyboardRemove())
+            return ConversationHandler.END
+        except AttributeError:
+            await update.message.reply_text("Cookies错误，请检查是否正确", reply_markup=ReplyKeyboardRemove())
+            return ConversationHandler.END
+        except ValueError:
+            await update.message.reply_text("Cookies错误，请检查是否正确", reply_markup=ReplyKeyboardRemove())
             return ConversationHandler.END
         cookies_command_data.cookies = cookies
         cookies_command_data.game_uid = user_info.uid


### PR DESCRIPTION
### 复现例子
绑定Cookie输入 
account_id=000
### 抛出错误
```
Traceback (most recent call last):
  File "/home/test/anaconda3/envs/TGPaimonBot/lib/python3.9/site-packages/python_telegram_bot-20.0a1-py3.9.egg/telegram/ext/_application.py", line 970, in process_update
    await coroutine
  File "/home/test/anaconda3/envs/TGPaimonBot/lib/python3.9/site-packages/python_telegram_bot-20.0a1-py3.9.egg/telegram/ext/_conversationhandler.py", line 811, in handle_update
    new_state: object = await handler.handle_update(
  File "/home/test/anaconda3/envs/TGPaimonBot/lib/python3.9/site-packages/python_telegram_bot-20.0a1-py3.9.egg/telegram/ext/_handler.py", line 137, in handle_update
    return await self.callback(update, context)
  File "/root/Projects/TGPaimonBot/plugins/errorhandler.py", line 59, in decorator
    return await func(*args, **kwargs)
  File "/root/Projects/TGPaimonBot/plugins/cookies.py", line 135, in check_cookies
    user_info = await client.get_record_card()
  File "/home/test/anaconda3/envs/TGPaimonBot/lib/python3.9/site-packages/genshin/client/components/chronicle/base.py", line 93, in get_record_card
    cards = await self.get_record_cards(hoyolab_uid, lang=lang)
  File "/home/test/anaconda3/envs/TGPaimonBot/lib/python3.9/site-packages/genshin/client/components/chronicle/base.py", line 68, in get_record_cards
    hoyolab_uid = hoyolab_uid or self.cookie_manager.get_user_id()
  File "/home/test/anaconda3/envs/TGPaimonBot/lib/python3.9/site-packages/genshin/client/manager.py", line 107, in get_user_id
    raise ValueError(f"Hoyolab ID must be provided when using {self.__class__}")
ValueError: Hoyolab ID must be provided when using <class 'genshin.client.manager.CookieManager'>
```

我™谢谢群友没事在酒店点意大利炮