### PR TITLE
修改 `conversation_error_handler` 能够识别多种 `InvalidCookies` 错误

### DIFF
--- a/plugins/errorhandler.py
+++ b/plugins/errorhandler.py
@@ -71,7 +71,12 @@ def conversation_error_handler(func: Callable) -> Callable:
             return ConversationHandler.END
         except InvalidCookies as exc:
             Log.warning("Cookie错误", exc)
-            await send_user_notification(update, context, "Cookies已经过期，请尝试重新绑定账户")
+            if "10001" in str(exc):
+                await send_user_notification(update, context, "Cookies无效，请尝试重新绑定账户")
+            elif "10103" in str(exc):
+                await send_user_notification(update, context, "Cookie有效，但没有绑定到游戏帐户。")
+            else:
+                await send_user_notification(update, context, "Cookies无效，具体原因未知")
             return ConversationHandler.END
         except TooManyRequests as exc:
             Log.warning("查询次数太多（操作频繁）", exc)


### PR DESCRIPTION
修改 `conversation_error_handler` 能够识别多种 `InvalidCookies` 错误

### 错误信息
10101 错误
`genshin.errors.InvalidCookies: [10001] Cookies are not valid.`
10103 错误
`genshin.errors.InvalidCookies: [10103] Cookies are valid but do not have a hoyolab account bound to them.`