### PR TITLE
⬆ 更新依赖 2022.8.27

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ pyppeteer~=1.0.2
 lxml>=4.9.0
 fakeredis>=1.8.1
 aiohttp<=3.8.1
-python-telegram-bot==20.0a2
+python-telegram-bot==20.0a4
 pytz>=2021.3
 Pillow>=9.0.1
 SQLAlchemy>=1.4.39

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,3 +22,4 @@ SQLAlchemy>=1.4.39
 sqlmodel>=0.0.6
 asyncmy>=0.2.5
 python-dotenv>=0.20.0
+aiolimiter>=1.0.0


### PR DESCRIPTION
✨ 更新依赖，更新功能

根据新文档，上游BOT框架添加新功能洪水限制 ，尝试取代旧的洪水限制