### PR TITLE
🎨 改进 `daily_material` 模块

### DIFF
--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -146,7 +146,7 @@ class DailyMaterial(Plugin, BasePlugin):
         full = bool(args and args[-1] == 'full')  # 判定最后一个参数是不是 full
 
         logger.info(
-            f"用户 {user.full_name}[{user.id}] 每日素材命令请求 || 参数 weekday={WEEK_MAP[weekday]} full={full}")
+            f"用户 {user.full_name}[{user.id}] 每日素材命令请求 || 参数 weekday=\"{WEEK_MAP[weekday]}\" full={full}")
 
         if weekday == 6:
             await update.message.reply_text(

--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -1,5 +1,4 @@
 import asyncio
-import itertools
 import re
 from asyncio import Lock
 from ctypes import c_double
@@ -11,6 +10,7 @@ from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
 import ujson as json
 from aiofiles import open as async_open
+from arkowrapper import ArkoWrapper
 from bs4 import BeautifulSoup
 from genshin import Client
 from httpx import AsyncClient, HTTPError
@@ -31,7 +31,7 @@ from utils.bot import get_all_args
 from utils.decorators.admins import bot_admins_rights_check
 from utils.decorators.error import error_callable
 from utils.decorators.restricts import restricts
-from utils.helpers import get_genshin_client, is_number
+from utils.helpers import get_genshin_client
 from utils.log import logger
 
 DATA_TYPE = Dict[str, List[List[str]]]
@@ -45,18 +45,26 @@ WEEK_MAP = ['一', '二', '三', '四', '五', '六', '日']
 def sort_item(items: List['ItemData']) -> Iterable['ItemData']:
     """对武器和角色进行排序
 
-    角色排序规则：星级>等级>命座
-    武器排序规则：星级>等级>精炼度
+    排序规则：持有（星级 > 等级 > 命座/精炼) > 未持有（星级 > 等级 > 命座/精炼）
     """
-    result_a = []
-    for _, group_a in itertools.groupby(sorted(items, key=lambda x: x.rarity, reverse=True), lambda x: x.rarity):
-        result_b = []
-        for _, group_b in itertools.groupby(
-                sorted(group_a, key=lambda x: x.level or -1, reverse=True), lambda x: x.level or -1
-        ):
-            result_b.append(sorted(group_b, key=lambda x: x.constellation or x.refinement or -1, reverse=True))
-        result_a.append(itertools.chain(*result_b))
-    return itertools.chain(*result_a)
+    return (
+        ArkoWrapper(items)
+        .sort(lambda x: x.level or -1, reverse=True)
+        .groupby(lambda x: x.level is None)
+        .map(
+            lambda x: (
+                ArkoWrapper(x[1])
+                .sort(lambda y: y.rarity, reverse=True)
+                .groupby(lambda y: y.rarity)
+                .map(lambda y: (
+                    ArkoWrapper(y[1])
+                    .sort(lambda z: z.refinement or z.constellation or -1, reverse=True)
+                    .groupby(lambda z: z.refinement or z.constellation or -1)
+                    .map(lambda i: ArkoWrapper(i[1]).sort(lambda j: j.id))
+                ))
+            )
+        ).flat(3)
+    )
 
 
 class DailyMaterial(Plugin, BasePlugin):
@@ -126,23 +134,16 @@ class DailyMaterial(Plugin, BasePlugin):
         args = get_all_args(context)
         now = datetime.now()
 
-        if args and is_number(args[0]):
-            # 适配出现 负数、小数、数字大于 7 、Nan 和 1e-10的状况
-            try:
-                weekday = (_ := int(args[0])) - (_ > 0)
-                weekday = (weekday % 7 + 7) % 7
-                time = title = f"星期{WEEK_MAP[weekday]}"
-            except ValueError:
-                title = "今日"
-                weekday = now.weekday() - (1 if now.hour < 4 else 0)
-                weekday = 6 if weekday < 0 else weekday
-                time = now.strftime("%m-%d %H:%M") + " 星期" + WEEK_MAP[weekday]
-        else:  # 获取今日是星期几，判定了是否过了凌晨4点
+        try:
+            weekday = (_ := int(args[0])) - (_ > 0)
+            weekday = (weekday % 7 + 7) % 7
+            time = title = f"星期{WEEK_MAP[weekday]}"
+        except (ValueError, IndexError):
             title = "今日"
             weekday = now.weekday() - (1 if now.hour < 4 else 0)
             weekday = 6 if weekday < 0 else weekday
             time = now.strftime("%m-%d %H:%M") + " 星期" + WEEK_MAP[weekday]
-        full = args and args[-1] == 'full'  # 判定最后一个参数是不是 full
+        full = bool(args and args[-1] == 'full')  # 判定最后一个参数是不是 full
 
         logger.info(
             f"用户 {user.full_name}[{user.id}] 每日素材命令请求 || 参数 weekday={WEEK_MAP[weekday]} full={full}")
@@ -208,7 +209,8 @@ class DailyMaterial(Plugin, BasePlugin):
                     path = (await self.assets_service.material(mid).icon()).as_uri()
                     material = HONEY_ID_MAP['material'][mid]
                     materials.append(ItemData(id=mid, icon=path, name=material[0], rarity=material[1]))
-                areas.append(AreaData(name=area_data['name'], materials=materials, items=sort_item(items)))
+                _items = sort_item(items)
+                areas.append(AreaData(name=area_data['name'], materials=materials, items=_items))
             setattr(render_data, type_, areas)
 
         await update.message.reply_chat_action(ChatAction.TYPING)

--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -212,7 +212,6 @@ class DailyMaterial(Plugin, BasePlugin):
                             if i.rarity > 3:  # 跳过 3 星及以下的武器
                                 items.append(i)
                             added = True
-                            break
                     if added:
                         continue
                     item = HONEY_ID_MAP[type_][id_]

--- a/poetry.lock
+++ b/poetry.lock
@@ -712,7 +712,7 @@ websockets = ">=10.0,<11.0"
 
 [[package]]
 name = "Pyrogram"
-version = "2.0.52"
+version = "2.0.54"
 description = "Elegant, modern and asynchronous Telegram MTProto API framework in Python for users and bots"
 category = "main"
 optional = true
@@ -1107,7 +1107,7 @@ test = ["pytest", "pytest-asyncio", "flaky"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "6f6b305fe0c8dd03db2612ea232f6e2bcec3dc04462a932f2b173af886008b1b"
+content-hash = "42739dc3305e46d19d971da975954a0340b59b91579a742c33ded7369bbacad5"
 
 [metadata.files]
 aiofiles = [
@@ -1842,8 +1842,8 @@ pyppeteer = [
     {file = "pyppeteer-1.0.2.tar.gz", hash = "sha256:ddb0d15cb644720160d49abb1ad0d97e87a55581febf1b7531be9e983aad7742"},
 ]
 Pyrogram = [
-    {file = "Pyrogram-2.0.52-py3-none-any.whl", hash = "sha256:a9d12bc5472e351e1aeba1531b2589bec66448c6b466e66eff0067b377e685f6"},
-    {file = "Pyrogram-2.0.52.tar.gz", hash = "sha256:7093af4ed0e8931eae2b0301960266d8eeb746b6117f578cd1975e47c871c90b"},
+    {file = "Pyrogram-2.0.54-py3-none-any.whl", hash = "sha256:495a621351de57eb44018a57c08a397752ec96fce346bac944deb29d6f6edfc2"},
+    {file = "Pyrogram-2.0.54.tar.gz", hash = "sha256:9295c57f4511bd3a58dde9379d408e7c11dc9cc80f8abc63829de51611b2b67a"},
 ]
 PySocks = [
     {file = "PySocks-1.7.1-py27-none-any.whl", hash = "sha256:08e69f092cc6dbe92a0fdd16eeb9b9ffbc13cadfe5ca4c7bd92ffb078b293299"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -118,6 +118,20 @@ twisted = ["twisted"]
 zookeeper = ["kazoo"]
 
 [[package]]
+name = "arko-wrapper"
+version = "0.2.3"
+description = "给你的Python迭代器加上魔法"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+test = ["pytest", "pytest-rerunfailures"]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
@@ -1093,7 +1107,7 @@ test = ["pytest", "pytest-asyncio", "flaky"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c6b8969a26c8469810af5a47b2f0726c969ee706c76bcb6cd6e616dee244add3"
+content-hash = "6f6b305fe0c8dd03db2612ea232f6e2bcec3dc04462a932f2b173af886008b1b"
 
 [metadata.files]
 aiofiles = [
@@ -1197,6 +1211,10 @@ appdirs = [
 APScheduler = [
     {file = "APScheduler-3.9.1-py2.py3-none-any.whl", hash = "sha256:ddc25a0ddd899de44d7f451f4375fb971887e65af51e41e5dcf681f59b8b2c9a"},
     {file = "APScheduler-3.9.1.tar.gz", hash = "sha256:65e6574b6395498d371d045f2a8a7e4f7d50c6ad21ef7313d15b1c7cf20df1e3"},
+]
+arko-wrapper = [
+    {file = "arko-wrapper-0.2.3.tar.gz", hash = "sha256:61927ac03c39c48d2514705b9af3642df30a200a7dd09e010131ebfe29774044"},
+    {file = "arko_wrapper-0.2.3-py3-none-any.whl", hash = "sha256:25f41c22b265324db44508ec8b1875bafd7193b667d5e64164d8fa638301b8a5"},
 ]
 async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
@@ -1692,8 +1710,8 @@ Pillow = [
     {file = "Pillow-9.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e"},
     {file = "Pillow-9.2.0-cp310-cp310-win32.whl", hash = "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28"},
     {file = "Pillow-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:408673ed75594933714482501fe97e055a42996087eeca7e5d06e33218d05aa8"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:727dd1389bc5cb9827cbd1f9d40d2c2a1a0c9b32dd2261db522d22a604a6eec9"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -118,6 +118,20 @@ twisted = ["twisted"]
 zookeeper = ["kazoo"]
 
 [[package]]
+name = "arko-wrapper"
+version = "0.2.3"
+description = "给你的Python迭代器加上魔法"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+test = ["pytest", "pytest-rerunfailures"]
+
+[[package]]
 name = "async-timeout"
 version = "4.0.2"
 description = "Timeout context manager for asyncio programs"
@@ -1093,7 +1107,7 @@ test = ["pytest", "pytest-asyncio", "flaky"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "ced17568ebbf432d28ae730835330b86fed0b7d210feb0d720e149c9ff1f3c18"
+content-hash = "f81ae57fa3826c77165605e7c30d9064e29f957825d5858ed6094df4f506e7a8"
 
 [metadata.files]
 aiofiles = [
@@ -1197,6 +1211,10 @@ appdirs = [
 APScheduler = [
     {file = "APScheduler-3.9.1-py2.py3-none-any.whl", hash = "sha256:ddc25a0ddd899de44d7f451f4375fb971887e65af51e41e5dcf681f59b8b2c9a"},
     {file = "APScheduler-3.9.1.tar.gz", hash = "sha256:65e6574b6395498d371d045f2a8a7e4f7d50c6ad21ef7313d15b1c7cf20df1e3"},
+]
+arko-wrapper = [
+    {file = "arko-wrapper-0.2.3.tar.gz", hash = "sha256:61927ac03c39c48d2514705b9af3642df30a200a7dd09e010131ebfe29774044"},
+    {file = "arko_wrapper-0.2.3-py3-none-any.whl", hash = "sha256:25f41c22b265324db44508ec8b1875bafd7193b667d5e64164d8fa638301b8a5"},
 ]
 async-timeout = [
     {file = "async-timeout-4.0.2.tar.gz", hash = "sha256:2163e1640ddb52b7a8c80d0a67a08587e5d245cc9c553a74a847056bc2976b15"},
@@ -1692,8 +1710,8 @@ Pillow = [
     {file = "Pillow-9.2.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:37ff6b522a26d0538b753f0b4e8e164fdada12db6c6f00f62145d732d8a3152e"},
     {file = "Pillow-9.2.0-cp310-cp310-win32.whl", hash = "sha256:c79698d4cd9318d9481d89a77e2d3fcaeff5486be641e60a4b49f3d2ecca4e28"},
     {file = "Pillow-9.2.0-cp310-cp310-win_amd64.whl", hash = "sha256:254164c57bab4b459f14c64e93df11eff5ded575192c294a0c49270f22c5d93d"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_x86_64.whl", hash = "sha256:adabc0bce035467fb537ef3e5e74f2847c8af217ee0be0455d4fec8adc0462fc"},
-    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:336b9036127eab855beec9662ac3ea13a4544a523ae273cbf108b228ecac8437"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_10_10_universal2.whl", hash = "sha256:408673ed75594933714482501fe97e055a42996087eeca7e5d06e33218d05aa8"},
+    {file = "Pillow-9.2.0-cp311-cp311-macosx_11_0_universal2.whl", hash = "sha256:727dd1389bc5cb9827cbd1f9d40d2c2a1a0c9b32dd2261db522d22a604a6eec9"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50dff9cc21826d2977ef2d2a205504034e3a4563ca6f5db739b0d1026658e004"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cb6259196a589123d755380b65127ddc60f4c64b21fc3bb46ce3a6ea663659b0"},
     {file = "Pillow-9.2.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7b0554af24df2bf96618dac71ddada02420f946be943b181108cac55a7a2dcd4"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ pytest = { version = "^7.1.3", optional = true }
 pytest-asyncio = { version = "^0.19.0", optional = true }
 flaky = { version = "^3.7.0", optional = true }
 lxml = "^4.9.1"
+arko-wrapper = "^0.2.2"
 
 [tool.poetry.extras]
 pyro = ["Pyrogram", "TgCrypto"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ pytest = { version = "^7.1.3", optional = true }
 pytest-asyncio = { version = "^0.19.0", optional = true }
 flaky = { version = "^3.7.0", optional = true }
 lxml = "^4.9.1"
-arko-wrapper = "^0.2.2"
+arko-wrapper = "^0.2.3"
 
 [tool.poetry.extras]
 pyro = ["Pyrogram", "TgCrypto"]

--- a/resources/genshin/daily_material/character.html
+++ b/resources/genshin/daily_material/character.html
@@ -43,7 +43,7 @@
                 <div class="area-content">
                     {% for item in area.items %}
                         <div class="item character"
-                                {% if item.level == none or item.level == 90 %}
+                                {% if data.uid != none and item.level == none or item.level == 90 %}
                              style="filter: grayscale(80%);"
                                 {% endif %}
                         >

--- a/resources/genshin/daily_material/character.html
+++ b/resources/genshin/daily_material/character.html
@@ -22,8 +22,11 @@
         {% for area in data.character %}
             <div class="area">
                 <div class="area-head">
-                    <img src="./bg/area/{{ loop.index0 }}.png" alt="{{ area.name }}"/>
-                    <span>{{ area.name }}</span>
+                    <span class="area-name">
+                        <img src="./bg/area/{{ loop.index0 }}.png" alt="{{ area.name }}"/>
+                        <div>{{ area.name }}</div>
+                    </span>
+                    <span class="material-name">{{ area.material_name }}</span>
                     <span class="materials">
                         {% for material in area.materials %}
                             <div class="material">

--- a/resources/genshin/daily_material/character.html
+++ b/resources/genshin/daily_material/character.html
@@ -42,7 +42,11 @@
                 </div>
                 <div class="area-content">
                     {% for item in area.items %}
-                        <div class="item character">
+                        <div class="item character"
+                                {% if item.level == none or item.level == 90 %}
+                             style="filter: grayscale(80%);"
+                                {% endif %}
+                        >
                             <div class="item-icon"
                                  style="background-image: url(./bg/rarity/full/{{ item.rarity }}.png)">
                                 {% if item.level != none %}

--- a/resources/genshin/daily_material/character.html
+++ b/resources/genshin/daily_material/character.html
@@ -43,7 +43,7 @@
                 <div class="area-content">
                     {% for item in area.items %}
                         <div class="item character"
-                                {% if data.uid != none and item.level == none or item.level == 90 %}
+                                {% if data.uid != none and item.level == none %}
                              style="filter: grayscale(80%);"
                                 {% endif %}
                         >

--- a/resources/genshin/daily_material/example.html
+++ b/resources/genshin/daily_material/example.html
@@ -18,42 +18,47 @@
         <div class="title">角色培养素材</div>
         <div class="area">
             <div class="area-head">
-                <img src="./bg/area/0.png" alt="蒙德"/>
-                <span>蒙德</span>
+                <span class="area-name">
+                    <img src="./bg/area/0.png" alt="蒙德"/>
+                    <div>蒙德</div>
+                </span>
+                <span class="material-name">
+                    自由
+                </span>
                 <span class="materials">
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/2.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/2.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
                         </div>
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/3.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
                         </div>
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/4.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                    </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/3.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
                         </div>
-                        <div class="material">
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                        </div>
+                    </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/4.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
+                        </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                        </div>
+                    </div>
+                    <div class="material">
                             <div class="material-icon" style="background-image: url(./bg/rarity/half/5.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
+                                <img alt="" src="../../assets/material/i_21/icon.webp"/>
                             </div>
                             <div class="material-star">
                                 <img alt="star" src="./bg/rarity/star.webp"/>
@@ -125,33 +130,47 @@
         </div>
         <div class="area">
             <div class="area-head">
-                <img src="./bg/area/0.png" alt="蒙德"/>
-                <span>蒙德</span>
+                <span class="area-name">
+                    <img src="./bg/area/0.png" alt="蒙德"/>
+                    <div>蒙德</div>
+                </span>
+                <span class="material-name">
+                    自由
+                </span>
                 <span class="materials">
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/3.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/2.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
                         </div>
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/4.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
                         </div>
-                        <div class="material">
+                    </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/3.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
+                        </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                        </div>
+                    </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/4.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
+                        </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                        </div>
+                    </div>
+                    <div class="material">
                             <div class="material-icon" style="background-image: url(./bg/rarity/half/5.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
+                                <img alt="" src="../../assets/material/i_21/icon.webp"/>
                             </div>
                             <div class="material-star">
                                 <img alt="star" src="./bg/rarity/star.webp"/>
@@ -164,6 +183,16 @@
                 </span>
             </div>
             <div class="area-content">
+                <div class="item character" style="filter: grayscale(80%);">
+                    <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
+                        <div>Lv.90</div>
+                        <div style="background-color: rgba(255, 20, 147, 0.8); backdrop-filter: blur(3px);">6命</div>
+                        <img src="../../assets/character/itto_057/icon.webp" alt="神里绫华"/>
+                    </div>
+                    <div class="item-name">
+                        <div>神里绫华</div>
+                    </div>
+                </div>
                 <div class="item character">
                     <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
                         <div>Lv.90</div>
@@ -178,6 +207,31 @@
                     <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
                         <div>Lv.90</div>
                         <div style="background-color: rgba(255, 20, 147, 0.8); backdrop-filter: blur(3px);">6命</div>
+                        <img src="../../assets/character/ayaka_002/icon.webp" alt="神里绫华"/>
+                    </div>
+                    <div class="item-name">
+                        <div>神里绫华</div>
+                    </div>
+                </div>
+                <div class="item character">
+                    <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
+                        <div>Lv.90</div>
+                        <img src="../../assets/character/ayaka_002/icon.webp" alt="神里绫华"/>
+                    </div>
+                    <div class="item-name">
+                        <div>神里绫华</div>
+                    </div>
+                </div>
+                <div class="item character">
+                    <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
+                        <img src="../../assets/character/ayaka_002/icon.webp" alt="神里绫华"/>
+                    </div>
+                    <div class="item-name">
+                        <div>神里绫华</div>
+                    </div>
+                </div>
+                <div class="item character">
+                    <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
                         <img src="../../assets/character/ayaka_002/icon.webp" alt="神里绫华"/>
                     </div>
                     <div class="item-name">
@@ -192,42 +246,47 @@
         <div class="title">武器培养素材</div>
         <div class="area">
             <div class="area-head">
-                <img src="./bg/area/0.png" alt="蒙德"/>
-                <span>蒙德</span>
+                <span class="area-name">
+                    <img src="./bg/area/2.png" alt="稻妻"/>
+                    <div>稻妻</div>
+                </span>
+                <span class="material-name">
+                    雾海云间
+                </span>
                 <span class="materials">
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/2.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/2.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
                         </div>
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/3.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
                         </div>
-                        <div class="material">
-                            <div class="material-icon" style="background-image: url(./bg/rarity/half/4.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
-                            </div>
-                            <div class="material-star">
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                                <img alt="star" src="./bg/rarity/star.webp"/>
-                            </div>
+                    </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/3.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
                         </div>
-                        <div class="material">
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                        </div>
+                    </div>
+                    <div class="material">
+                        <div class="material-icon" style="background-image: url(./bg/rarity/half/4.png)">
+                            <img alt="" src="../../assets/material/i_21/icon.webp"/>
+                        </div>
+                        <div class="material-star">
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                            <img alt="star" src="./bg/rarity/star.webp"/>
+                        </div>
+                    </div>
+                    <div class="material">
                             <div class="material-icon" style="background-image: url(./bg/rarity/half/5.png)">
-                                <img alt="" src="../../assets/material/i_502.webp"/>
+                                <img alt="" src="../../assets/material/i_21/icon.webp"/>
                             </div>
                             <div class="material-star">
                                 <img alt="star" src="./bg/rarity/star.webp"/>

--- a/resources/genshin/daily_material/example.html
+++ b/resources/genshin/daily_material/example.html
@@ -66,7 +66,7 @@
                 </span>
             </div>
             <div class="area-content">
-                <div class="item character">
+                <div class="item character" style="filter: grayscale(80%);">
                     <div class="item-icon" style="background-image: url(./bg/rarity/full/5.png)">
                         <div>Lv.90</div>
                         <div style="background-color: rgba(255, 20, 147, 0.8); backdrop-filter: blur(3px);">6命</div>

--- a/resources/genshin/daily_material/style.css
+++ b/resources/genshin/daily_material/style.css
@@ -106,23 +106,24 @@ body {
     top: 50%;
     left: 88px;
     transform: translateY(-50%);
-    font-size: 25px;
+    font-size: 28px;
 }
 
 .material-name {
     top: 0 !important;
     right: 269px;
     z-index: 2;
-    padding: 0 20px;
+    padding: 2px 20px;
     min-width: 100px;
-    height: 40px;
+    min-height: 40px;
     border-radius: 20px 5px 20px 20px;
     background-color: rgb(246 222 169 / 50%);
     backdrop-filter: blur(5px);
     display: flex;
     justify-content: center;
     align-items: center;
-    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.5);
+    box-shadow: 3px 3px 5px rgb(0 0 0 / 50%);
+    font-size: 24px !important;
 }
 
 .materials {

--- a/resources/genshin/daily_material/style.css
+++ b/resources/genshin/daily_material/style.css
@@ -69,21 +69,14 @@ body {
 .area {
     width: calc(100% - 20px);
     padding: 0 10px;
+    margin: 40px 0;
 }
 
 .area-head {
-    background-image: url("bg/title/01.png");
-    background-size: contain;
     width: calc(100% - 20px);
     height: 80px;
-    filter: drop-shadow(5px 5px 5px var(--shadow));
     position: relative;
     padding-left: 15px;
-}
-
-.area-head > img {
-    height: inherit;
-    filter: drop-shadow(3px 3px 5px black);
 }
 
 .area-head > span {
@@ -91,6 +84,45 @@ body {
     position: absolute;
     top: 50%;
     transform: translateY(-50%);
+}
+
+.area-name {
+    background-image: url("bg/title/01.png");
+    background-size: contain;
+    height: inherit;
+    width: 356px;
+    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
+}
+
+.area-name > img {
+    height: inherit;
+    filter: drop-shadow(3px 3px 5px black);
+    position: relative;
+    left: 5px;
+}
+
+.area-name > div {
+    position: absolute;
+    top: 50%;
+    left: 88px;
+    transform: translateY(-50%);
+    font-size: 25px;
+}
+
+.material-name {
+    top: 0 !important;
+    right: 269px;
+    z-index: 2;
+    padding: 0 20px;
+    min-width: 100px;
+    height: 40px;
+    border-radius: 20px 5px 20px 20px;
+    background-color: rgb(246 222 169 / 50%);
+    backdrop-filter: blur(5px);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    box-shadow: 3px 3px 5px rgba(0, 0, 0, 0.5);
 }
 
 .materials {
@@ -105,6 +137,26 @@ body {
     position: relative;
     top: 50%;
     transform: translateY(-50%);
+    filter: drop-shadow(3px 3px 5px rgba(0, 0, 0, 0.8));
+}
+
+.materials > div:not(.material) {
+    position: absolute;
+    width: 100px;
+    height: 35px;
+    background: rgb(246 222 169 / 80%);
+    left: -35px;
+    top: -15px;
+    z-index: 2;
+    box-shadow: 1px 1px 10px rgb(0 0 0 / 20%);
+    border-radius: 20px 5px 20px 20px;
+    backdrop-filter: blur(10px);
+    text-align: center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    font-size: 20px;
+    color: rgb(255 255 255);
 }
 
 .material {

--- a/resources/genshin/daily_material/weapon.html
+++ b/resources/genshin/daily_material/weapon.html
@@ -43,7 +43,7 @@
                 <div class="area-content">
                     {% for item in area.items %}
                         <div class="item weapon"
-                                {% if data.uid != none and item.level == none or item.level == 90 %}
+                                {% if data.uid != none and (item.level == none or item.level >= 81) %}
                              style="filter: grayscale(80%);"
                                 {% endif %}
                         >

--- a/resources/genshin/daily_material/weapon.html
+++ b/resources/genshin/daily_material/weapon.html
@@ -22,8 +22,11 @@
         {% for area in data.weapon %}
             <div class="area">
                 <div class="area-head">
-                    <img src="./bg/area/{{ loop.index0 }}.png" alt="{{ area.name }}"/>
-                    <span>{{ area.name }}</span>
+                    <span class="area-name">
+                        <img src="./bg/area/{{ loop.index0 }}.png" alt="{{ area.name }}"/>
+                        <div>{{ area.name }}</div>
+                    </span>
+                    <span class="material-name">{{ area.material_name }}</span>
                     <span class="materials">
                         {% for material in area.materials %}
                             <div class="material">

--- a/resources/genshin/daily_material/weapon.html
+++ b/resources/genshin/daily_material/weapon.html
@@ -43,7 +43,7 @@
                 <div class="area-content">
                     {% for item in area.items %}
                         <div class="item weapon"
-                                {% if item.level == none or item.level == 90 %}
+                                {% if data.uid != none and item.level == none or item.level == 90 %}
                              style="filter: grayscale(80%);"
                                 {% endif %}
                         >

--- a/resources/genshin/daily_material/weapon.html
+++ b/resources/genshin/daily_material/weapon.html
@@ -42,7 +42,11 @@
                 </div>
                 <div class="area-content">
                     {% for item in area.items %}
-                        <div class="item weapon">
+                        <div class="item weapon"
+                                {% if item.level == none or item.level == 90 %}
+                             style="filter: grayscale(80%);"
+                                {% endif %}
+                        >
                             {% if item.c_path != none %}
                                 <div class="role">
                                     <img src="{{ item.c_path }}" alt=""/>
@@ -58,9 +62,10 @@
                                         <div style="background-color: rgba(251,86,33, 0.8);backdrop-filter: blur(3px);">
                                             精炼5
                                         </div>
-                                    {% else %}
+                                    {% elif item.refinement != 1 %}
                                         <div style="background-color: rgba(103,167,230, 0.8);backdrop-filter: blur(3px);">
-                                            精炼{{ item.refinement }}</div>
+                                            精炼{{ item.refinement }}
+                                        </div>
                                     {% endif %}
                                 {% endif %}
                                 <img src="{{ item.icon }}" alt="{{ item.name }}"/>

--- a/utils/helpers.py
+++ b/utils/helpers.py
@@ -1,9 +1,7 @@
-import asyncio
 import hashlib
 import os
-from multiprocessing import RLock
 from pathlib import Path
-from typing import Optional, Tuple, Union, cast
+from typing import Iterator, Optional, Tuple, Union, cast
 
 import aiofiles
 import genshin
@@ -150,19 +148,3 @@ def mkdir(path: Path) -> Path:
         path_list.pop().mkdir(exist_ok=True)
 
     return path
-
-
-def is_number(target: str) -> bool:
-    """判断字符串是否是数字"""
-    try:  # 尝试将字符串转为浮点数
-        float(target)
-        return True
-    except ValueError:
-        pass
-    try:
-        import unicodedata  # 处理ASCii码的包
-        unicodedata.numeric(target)  # 把一个表示数字的字符串转换为浮点数返回的函数
-        return True
-    except (TypeError, ValueError):
-        pass
-    return False


### PR DESCRIPTION
1. 更新角色/武器排序规则：持有（星级 > 等级 > 命座/精炼) > 未持有（星级 > 等级 > 命座/精炼）
2. 更新样式：未持有或满级的角色/武器黑白显示
3. 在材料图标的左上角添加材料系列名
4. 展示所有已装备的武器


<details>
  <summary>修改前</summary>
  <p align="center">
    <img src="https://user-images.githubusercontent.com/70872201/190972266-ee10c764-58f1-464a-9e60-0e3221f9748b.png" width="400px" />
	<img src="https://user-images.githubusercontent.com/70872201/190972282-2006d002-0e3e-4fea-9f83-925d70fe2785.png" width="400px" />
  </p>
</details>
<details>
  <summary>修改后</summary>
  <p align="center">
    <img src="https://user-images.githubusercontent.com/70872201/191193827-9fe6e6e3-9ed0-4ead-8e12-5d9959a94344.png" width="400px" />
	<img src="https://user-images.githubusercontent.com/70872201/191193847-11b939d3-44ec-48f2-942b-6bc5bb27865c.png" width="400px" />
  </p>
</details>