### PR TITLE
✨ Send uid to geetest verification site

### DIFF
--- a/plugins/genshin/sign.py
+++ b/plugins/genshin/sign.py
@@ -80,7 +80,7 @@ class SignSystem:
         gt, challenge = await self.get_challenge(uid)
         if not challenge or not gt:
             return
-        url = f"{config.pass_challenge_user_web}?username={bot.app.bot.username}&gt={gt}&challenge={challenge}"
+        url = f"{config.pass_challenge_user_web}?username={bot.app.bot.username}&gt={gt}&challenge={challenge}&uid={uid}"
         return InlineKeyboardMarkup([[InlineKeyboardButton("请尽快点我进行手动验证", url=url)]])
 
     @staticmethod


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 描述 / Description

```
发送uid至手动打码页面 (sign.paimon.vip)

Sends genshin uid as part of the querystring to geetest verification site (i.e sign.paimon.vip)
```

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note

![image](https://user-images.githubusercontent.com/17893236/199241160-ba059843-251c-44f8-8b5a-e39e39da66e0.png)
