### PR TITLE
Add optional password for Redis

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,7 @@ DB_DATABASE=paimon
 REDIS_HOST=127.0.0.1
 REDIS_PORT=6379
 REDIS_DB=0
+REDIS_PASSWORD=""
 
 # 联系 https://t.me/BotFather 使用 /newbot 命令创建机器人并获取 token
 BOT_TOKEN="xxxxxxx"

--- a/core/base/redisdb.py
+++ b/core/base/redisdb.py
@@ -15,8 +15,8 @@ class RedisDB(Service):
     def from_config(cls, config: BotConfig) -> Self:
         return cls(**config.redis.dict())
 
-    def __init__(self, host="127.0.0.1", port=6379, database=0, loop=None):
-        self.client = aioredis.Redis(host=host, port=port, db=database)
+    def __init__(self, host="127.0.0.1", port=6379, database=0, loop=None, password=None):
+        self.client = aioredis.Redis(host=host, port=port, db=database, password=password)
         self.ttl = 600
         self.key_prefix = "paimon_bot"
         self._loop = loop

--- a/core/base/redisdb.py
+++ b/core/base/redisdb.py
@@ -1,4 +1,5 @@
 import asyncio
+from typing import Optional, Union
 
 import fakeredis.aioredis
 from redis import asyncio as aioredis
@@ -15,11 +16,12 @@ class RedisDB(Service):
     def from_config(cls, config: BotConfig) -> Self:
         return cls(**config.redis.dict())
 
-    def __init__(self, host="127.0.0.1", port=6379, database=0, loop=None, password=None):
+    def __init__(
+        self, host: str = "127.0.0.1", port: int = 6379, database: Union[str, int] = 0, password: Optional[str] = None
+    ):
         self.client = aioredis.Redis(host=host, port=port, db=database, password=password)
         self.ttl = 600
         self.key_prefix = "paimon_bot"
-        self._loop = loop
 
     async def ping(self):
         if await self.client.ping():
@@ -33,8 +35,6 @@ class RedisDB(Service):
         await self.ping()
 
     async def start(self):  # pylint: disable=W0221
-        if self._loop is None:
-            self._loop = asyncio.get_running_loop()
         logger.info("正在尝试建立与 [red]Redis[/] 连接", extra={"markup": True})
         try:
             await self.ping()

--- a/core/config.py
+++ b/core/config.py
@@ -48,8 +48,8 @@ class MySqlConfig(Settings):
 class RedisConfig(Settings):
     host: str = "127.0.0.1"
     port: int = 6379
-    database: int = Field(env="redis_db")
-    password: str = None
+    database: int = Field(default=0, env="redis_db")
+    password: Optional[str] = None
 
     class Config(Settings.Config):
         env_prefix = "redis_"

--- a/core/config.py
+++ b/core/config.py
@@ -49,6 +49,7 @@ class RedisConfig(Settings):
     host: str = "127.0.0.1"
     port: int = 6379
     database: int = Field(env="redis_db")
+    password: str = None
 
     class Config(Settings.Config):
         env_prefix = "redis_"


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

## 描述 / Description

为部分已部署好的带密码的 Redis 做了适配，增加了可选的密码。

### 配置文件
`.env.example` 与 `.env` 有字段变动，**增加了一行**：
```
REDIS_PASSWORD=""
```

### 代码
更改了 `core\config.py` 和 `core\base\redisdb.py` 与密码相关的部分。

经过测试，这部分更改对已部署好的系统无影响，无需更改现有的 `.env` 配置文件。

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [x] 本地通过了测试
  - [x] CI 通过了测试
