### PR TITLE
Fix: `avatar_list`: `AttributeError: 'NoneType' object has no attribute 'avatar' `

### DIFF
--- a/plugins/genshin/avatar_list.py
+++ b/plugins/genshin/avatar_list.py
@@ -158,7 +158,7 @@ class AvatarListPlugin(Plugin, BasePlugin):
         task_results = await asyncio.gather(*[_task(character) for character in characters])
 
         return sorted(
-            list(filter( lambda x: x, task_results)),
+            list(filter(lambda x: x, task_results)),
             key=lambda x: (
                 x.avatar.level,
                 x.avatar.rarity,
@@ -170,7 +170,7 @@ class AvatarListPlugin(Plugin, BasePlugin):
                 # x.weapon.refinement,
                 x.avatar.friendship,
             ),
-            reverse=True
+            reverse=True,
         )[:max_length]
 
     async def get_final_data(self, client: Client, characters: Sequence[Character], update: Update):

--- a/plugins/genshin/avatar_list.py
+++ b/plugins/genshin/avatar_list.py
@@ -157,26 +157,21 @@ class AvatarListPlugin(Plugin, BasePlugin):
 
         task_results = await asyncio.gather(*[_task(character) for character in characters])
 
-        return list(
-            filter(
-                lambda x: x,
-                sorted(
-                    task_results,
-                    key=lambda x: (
-                        x.avatar.level,
-                        x.avatar.rarity,
-                        x.sum_of_skills(),
-                        x.avatar.constellation,
-                        # TODO 如果加入武器排序条件，需要把武器转化为图片url的处理后置
-                        # x.weapon.level,
-                        # x.weapon.rarity,
-                        # x.weapon.refinement,
-                        x.avatar.friendship,
-                    ),
-                    reverse=True,
-                )[:max_length],
-            )
-        )
+        return sorted(
+            list(filter( lambda x: x, task_results)),
+            key=lambda x: (
+                x.avatar.level,
+                x.avatar.rarity,
+                x.sum_of_skills(),
+                x.avatar.constellation,
+                # TODO 如果加入武器排序条件，需要把武器转化为图片url的处理后置
+                # x.weapon.level,
+                # x.weapon.rarity,
+                # x.weapon.refinement,
+                x.avatar.friendship,
+            ),
+            reverse=True
+        )[:max_length]
 
     async def get_final_data(self, client: Client, characters: Sequence[Character], update: Update):
         try:


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue


## 描述 / Description

这块逻辑改的时候没完全搞懂，大概传进来的 Character 可能会为 `None`，上次改动的时候没注意。

https://github.com/luoshuijs/TGPaimonBot/commit/7013a61f49920295392bed1438b53da025fb8e1a#diff-20f7e91056affab397adb843cbec7371e70c06b9960f74abeab678a2f7c536d2

```python3
    async def get_avatars_data(
        self, characters: Sequence[Character], client: Client, max_length: int = None
    ) -> List["AvatarData"]:
        async def _task(c, n):
            return n, await self.get_avatar_data(c, client)

        task_results = await asyncio.gather(
            *[_task(character, num) for num, character in enumerate(characters[:max_length])]
        )

        return list(filter(lambda x: x, map(lambda x: x[1], sorted(task_results, key=lambda x: x[0]))))
```

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [x] 本地通过了测试
  - [x] CI 通过了测试
