### PR TITLE
🎨 move all `user_mismatch` notice to the same place

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -79,3 +79,6 @@ LOGGER_FILTERED_NAMES=["uvicorn","ErrorPush","ApiHelper"]
 # ERROR_PB_SUNSET=43200
 # ERROR_PB_MAX_LINES=1000
 # ERROR_SENTRY_DSN=
+
+# Notice
+NOTICE_USER_MISMATCH="再乱点我叫西风骑士团、千岩军、天领奉行、三十人团和风纪官了！"

--- a/core/config.py
+++ b/core/config.py
@@ -95,6 +95,12 @@ class ErrorConfig(Settings):
     class Config(Settings.Config):
         env_prefix = "error_"
 
+class NoticeConfig(Settings):
+    user_mismatch: str = "再乱点我叫西风骑士团、千岩军、天领奉行、三十人团和风纪官了！"
+
+    class Config(Settings.Config):
+        env_prefix = "notice_"
+
 
 class BotConfig(Settings):
     debug: bool = False
@@ -125,6 +131,7 @@ class BotConfig(Settings):
     redis: RedisConfig = RedisConfig()
     mtproto: MTProtoConfig = MTProtoConfig()
     error: ErrorConfig = ErrorConfig()
+    notice: NoticeConfig = NoticeConfig()
 
 
 BotConfig.update_forward_refs()

--- a/core/config.py
+++ b/core/config.py
@@ -95,6 +95,7 @@ class ErrorConfig(Settings):
     class Config(Settings.Config):
         env_prefix = "error_"
 
+
 class NoticeConfig(Settings):
     user_mismatch: str = "再乱点我叫西风骑士团、千岩军、天领奉行、三十人团和风纪官了！"
 

--- a/plugins/genshin/player_cards.py
+++ b/plugins/genshin/player_cards.py
@@ -157,7 +157,7 @@ class PlayerCards(Plugin, BasePlugin):
 
         result, user_id, uid = await get_player_card_callback(callback_query.data)
         if user.id != user_id:
-            await callback_query.answer(text="这不是你的按钮！\n" "再乱点再按我叫西风骑士团、千岩军、天领奉行和教令院了！", show_alert=True)
+            await callback_query.answer(text="这不是你的按钮！\n" + config.notice.user_mismatch, show_alert=True)
             return
         logger.info(f"用户 {user.full_name}[{user.id}] 角色卡片查询命令请求 || character_name[{result}] uid[{uid}]")
         data = await self._fetch_user(uid)

--- a/plugins/genshin/sign.py
+++ b/plugins/genshin/sign.py
@@ -424,7 +424,7 @@ class Sign(Plugin, BasePlugin):
 
         user_id, uid = await get_sign_callback(callback_query.data)
         if user.id != user_id:
-            await callback_query.answer(text="这不是你的按钮！\n" "再乱点再按我叫西风骑士团、千岩军、天领奉行和教令院了！", show_alert=True)
+            await callback_query.answer(text="这不是你的按钮！\n" + config.notice.user_mismatch, show_alert=True)
             return
         _, challenge = await self.system.get_challenge(uid)
         if not challenge:

--- a/plugins/system/auth.py
+++ b/plugins/system/auth.py
@@ -12,6 +12,7 @@ from telegram.helpers import escape_markdown
 from core.base.mtproto import MTProto
 from core.base.redisdb import RedisDB
 from core.bot import bot
+from core.config import config
 from core.plugin import Plugin, handler
 from core.quiz import QuizService
 from utils.chatmember import extract_status_change
@@ -151,7 +152,7 @@ class GroupJoiningVerification(Plugin):
         chat_administrators = await self.get_chat_administrators(context, chat_id=chat.id)
         if not self.is_admin(chat_administrators, user.id):
             logger.debug(f"用户 {user.full_name}[{user.id}] 在群 {chat.title}[{chat.id}] 非群管理")
-            await callback_query.answer(text="你不是管理！\n" "再乱点我叫西风骑士团、千岩军和天领奉行了！", show_alert=True)
+            await callback_query.answer(text="你不是管理！\n" + config.notice.user_mismatch, show_alert=True)
             return
         result, user_id = await admin_callback(callback_query.data)
         try:
@@ -216,7 +217,7 @@ class GroupJoiningVerification(Plugin):
         user_id, result, question, answer = await query_callback(callback_query.data)
         logger.info(f"用户 {user.full_name}[{user.id}] 在群 {chat.title}[{chat.id}] 点击Auth认证命令 ")
         if user.id != user_id:
-            await callback_query.answer(text="这不是你的验证！\n" "再乱点再按我叫西风骑士团、千岩军和天领奉行了！", show_alert=True)
+            await callback_query.answer(text="这不是你的验证！\n" + config.notice.user_mismatch, show_alert=True)
             return
         logger.info(f"用户 {user.full_name}[{user.id}] 在群 {chat.title}[{chat.id}] 认证结果为 {'通过' if result else '失败'}")
         if result:


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

## 描述 / Description

用户乱按按钮的文本提示已经散乱在3个模块的不同文件中了，其中已经了出现版本不一致的地方，最好重构一下，统一引用相同的提示文本。

这里在 `.env` 和 `.config` 里面增加了对应的项，后续也可以把其他会多次出现的提示文本移到这里。

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试