### PR TITLE
🐛 fix abyss HTML template

### DIFF
--- a/resources/genshin/abyss/overview.html
+++ b/resources/genshin/abyss/overview.html
@@ -71,18 +71,26 @@
                             <span>最多承伤: {{ data.ranks.most_damage_taken[0].value }}</span>
                             <img src="{{ data.ranks.most_damage_taken[0].side_icon }}" alt=""/>
                         {% else %}
-                            <span>最多承伤: 0</span>
+                            <span>最多承伤: </span>
                         {% endif %}
                     </div>
                 </div>
                 <div style="background-color: rgb(61 76 86 / 60%);">
                     <div class="rank">
-                        <span>元素爆发: {{ data.ranks.most_bursts_used[0].value }}</span>
-                        <img src="{{ data.ranks.most_bursts_used[0].side_icon }}" alt=""/>
+                        {% if data.ranks.most_bursts_used is defined and data.ranks.most_bursts_used|length > 0 %}
+                            <span>元素爆发: {{ data.ranks.most_bursts_used[0].value }}</span>
+                            <img src="{{ data.ranks.most_bursts_used[0].side_icon }}" alt=""/>
+                        {% else %}
+                            <span>元素爆发: </span>
+                        {% endif %}
                     </div>
                     <div class="rank">
-                        <span>元素战技: {{ data.ranks.most_skills_used[0].value }}</span>
-                        <img src="{{ data.ranks.most_skills_used[0].side_icon }}" alt=""/>
+                        {% if data.ranks.most_skills_used is defined and data.ranks.most_skills_used|length > 0 %}
+                            <span>元素战技: {{ data.ranks.most_skills_used[0].value }}</span>
+                            <img src="{{ data.ranks.most_skills_used[0].side_icon }}" alt=""/>
+                        {% else %}
+                            <span>元素战技: </span>
+                        {% endif %}
                     </div>
                 </div>
             </div>

--- a/resources/genshin/abyss/overview.html
+++ b/resources/genshin/abyss/overview.html
@@ -67,8 +67,12 @@
                         <img src="{{ data.ranks.strongest_strike[0].side_icon }}" alt=""/>
                     </div>
                     <div class="rank">
-                        <span>最多承伤: {{ data.ranks.most_damage_taken[0].value }}</span>
-                        <img src="{{ data.ranks.most_damage_taken[0].side_icon }}" alt=""/>
+                        {% if data.ranks.most_damage_taken is defined and data.ranks.most_damage_taken|length > 0 %}
+                            <span>最多承伤: {{ data.ranks.most_damage_taken[0].value }}</span>
+                            <img src="{{ data.ranks.most_damage_taken[0].side_icon }}" alt=""/>
+                        {% else %}
+                            <span>最多承伤: 0</span>
+                        {% endif %}
                     </div>
                 </div>
                 <div style="background-color: rgb(61 76 86 / 60%);">


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 描述 / Description

when the maximum damage taken is empty, jinja raise `UndefinedError` when rendering template.
当最多承伤为空时，Jinja在渲染模板时会抛出 `UndefinedError`

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note

顺便修复深渊各个数据（元素爆发、元素战技等）为空时的情况。