### PR TITLE
:heavy_plus_sign: add cryptography as extra deps to `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ thefuzz = "^0.19.0"
 qrcode = "^7.3.1"
 
 [tool.poetry.extras]
-pyro = ["Pyrogram", "TgCrypto"]
+pyro = ["Pyrogram", "TgCrypto", "cryptography"]
 test = ["pytest", "pytest-asyncio", "flaky"]
-all = ["pytest", "pytest-asyncio", "flaky", "Pyrogram", "TgCrypto"]
+all = ["pytest", "pytest-asyncio", "flaky", "Pyrogram", "TgCrypto", "cryptography"]
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION

## 描述 / Description

~~在某些情况下，~~ cryptography作为asyncmy的可选依赖，可能会引发异常。
~~不过正常情况下应该触发不了这个问题，所以放到可选依赖里面吧…~~

```
  File "asyncmy/connection.pyx", line 1299, in _connect
  File "asyncmy/connection.pyx", line 555, in connect
  File "asyncmy/connection.pyx", line 533, in asyncmy.connection.Connection.connect
  File "asyncmy/connection.pyx", line 803, in _request_authentication
  File "/Users/nahida/Library/Caches/pypoetry/virtualenvs/tgpaimonbot-z76x0Eml-py3.11/lib/python3.11/site-packages/asyncmy/auth.py", line 243, in caching_sha2_password_auth
    data = sha2_rsa_encrypt(conn._password, conn.salt, conn._server_public_key)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/nahida/Library/Caches/pypoetry/virtualenvs/tgpaimonbot-z76x0Eml-py3.11/lib/python3.11/site-packages/asyncmy/auth.py", line 139, in sha2_rsa_encrypt
    raise RuntimeError(
RuntimeError: 'cryptography' package is required for sha256_password or caching_sha2_password auth methods
```

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [x] 添加了新的依赖包
- [ ] 测试
  - [x] 本地通过了测试
  - [ ] CI 通过了测试