### PR TITLE
:pushpin: constrain fastapi version to <0.100.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ pytest-asyncio = { version = "^0.21.0", optional = true }
 flaky = { version = "^3.7.0", optional = true }
 lxml = "^4.9.2"
 arko-wrapper = "^0.2.8"
-fastapi = "^0.99.1"
+fastapi = "<0.100.0"
 uvicorn = { extras = ["standard"], version = "^0.22.0" }
 sentry-sdk = "^1.27.1"
 GitPython = "^3.1.30"


### PR DESCRIPTION
`fastapi` 即将 Dump Pydantic V1
而我们一些上游如 `sqlmodel` 等重要依赖依然未准备 Pydantic V2
故将 `fastapi` 依赖项版本限制为＜0.100.0