### PR TITLE
Change the calculation for up-average pulls

### DIFF
--- a/modules/gacha_log/log.py
+++ b/modules/gacha_log/log.py
@@ -387,7 +387,11 @@ class GachaLog:
         # 五星常驻
         five_star_const = five_star - five_star_up
         # UP 平均
-        up_avg = round((total - no_five_star) / five_star_up, 2) if five_star_up != 0 else 0
+        up_avg = (
+            round((total - no_five_star - (all_five[0].count if not all_five[0].isUp else 0)) / five_star_up, 2)
+            if five_star_up != 0
+            else 0
+        )
         # UP 花费原石
         up_cost = sum(i.count * 160 for i in all_five if i.isUp)
         up_cost = f"{round(up_cost / 10000, 2)}w" if up_cost >= 10000 else up_cost


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

N/A

## 描述 / Description

The existing code for up-average pulls was:
```python
round((total - no_five_star) / five_star_up, 2)
```
The result of this would be biased when the last five-star pull is not up. Changing it like this:
```python
round((total - no_five_star - (all_five[0].count if not all_five[0].isUp else 0)) / five_star_up, 2)
```
can make it an unbiased estimator of the average (i.e. 93.75 pulls) of the up-average pulls.

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [x] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
