### PR TITLE
:bug: Fix incorrect matching with commands containing `@`

### DIFF
--- a/plugins/genshin/abyss.py
+++ b/plugins/genshin/abyss.py
@@ -29,7 +29,7 @@ except ImportError:
     import json as jsonlib
 
 TZ = timezone("Asia/Shanghai")
-cmd_pattern = r"(?i)^/abyss\s*((?:\d+)|(?:all))?\s*(pre)?"
+cmd_pattern = r"(?i)^/abyss(?:@[\w]+)?\s*((?:\d+)|(?:all))?\s*(pre)?"
 msg_pattern = r"^深渊数据((?:查询)|(?:总览))(上期)?\D?(\d*)?.*?$"
 
 regex_01 = r"['\"]icon['\"]:\s*['\"](.*?)['\"]"


### PR DESCRIPTION
Resolved the issue where commands with an '@' symbol, such as "/abyss@MasterBot", were not being matched correctly due to the regular expression pattern. The pattern has been updated to handle such cases.