### PR TITLE
:art: Shrink `daily_material` width to exactly 7 items per line

### DIFF
--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -9,14 +9,15 @@ from multiprocessing import Value
 from pathlib import Path
 from ssl import SSLZeroReturnError
 from time import time as time_
-from typing import Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Literal, Optional, Tuple
 
 from aiofiles import open as async_open
 from arkowrapper import ArkoWrapper
 from bs4 import BeautifulSoup
 from httpx import AsyncClient, HTTPError, TimeoutException
 from pydantic import BaseModel
-from simnet.errors import InvalidCookies, BadRequest as SimnetBadRequest
+from simnet.errors import BadRequest as SimnetBadRequest
+from simnet.errors import InvalidCookies
 from simnet.models.genshin.chronicle.characters import Character
 from telegram.constants import ChatAction, ParseMode
 from telegram.error import RetryAfter, TimedOut
@@ -26,7 +27,7 @@ from core.plugin import Plugin, handler
 from core.services.template.models import FileType, RenderGroupResult
 from core.services.template.services import TemplateService
 from metadata.genshin import AVATAR_DATA, HONEY_DATA
-from plugins.tools.genshin import CharacterDetails, PlayerNotFoundError, CookiesNotFoundError, GenshinHelper
+from plugins.tools.genshin import CharacterDetails, CookiesNotFoundError, GenshinHelper, PlayerNotFoundError
 from utils.log import logger
 from utils.uid import mask_number
 
@@ -37,10 +38,9 @@ except ImportError:
     import json as jsonlib
 
 if TYPE_CHECKING:
-    from telegram import Update
-    from telegram.ext import ContextTypes
     from simnet import GenshinClient
-    from telegram import Message, User
+    from telegram import Message, Update, User
+    from telegram.ext import ContextTypes
 
 INTERVAL = 1
 
@@ -327,14 +327,14 @@ class DailyMaterial(Plugin):
             self.template_service.render(  # 渲染角色素材页
                 "genshin/daily_material/character.jinja2",
                 {"data": render_data},
-                {"width": 2268, "height": 500},
+                {"width": 1338, "height": 500},
                 file_type=file_type,
                 ttl=30 * 24 * 60 * 60,
             ),
             self.template_service.render(  # 渲染武器素材页
                 "genshin/daily_material/weapon.jinja2",
                 {"data": render_data},
-                {"width": 2268, "height": 500},
+                {"width": 1338, "height": 500},
                 file_type=file_type,
                 ttl=30 * 24 * 60 * 60,
             ),

--- a/resources/genshin/daily_material/style.css
+++ b/resources/genshin/daily_material/style.css
@@ -25,7 +25,7 @@ body {
 }
 
 .container {
-    width: 2208px;
+    width: 1278px;
     background-color: var(--bg-color);
     position: absolute;
     left: 50%;


### PR DESCRIPTION
## 描述 / Description

将 `daily_material` 输出图像的宽度调整到 7 个元素宽。  
目前蒙德璃月角色天赋素材一天最多 7 人，武器最多 17 把，不过同一把武器可以重复出现。

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
