### PR TITLE
🔨Fix: changing server default task.time_created to CURRENT_TIMESTAMP

### DIFF
--- a/alembic/versions/1df05b897d3f_tasks.py
+++ b/alembic/versions/1df05b897d3f_tasks.py
@@ -33,7 +33,7 @@ def upgrade() -> None:
         sa.Column(
             "time_created",
             sa.DateTime(),
-            server_default=sa.text("now()"),
+            server_default=sa.text("(CURRENT_TIMESTAMP)"),
             nullable=True,
         ),
         sa.Column("time_updated", sa.DateTime(), nullable=True),


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue
N/A

## 描述 / Description

sqlite并不支持default设为"now()"，`(CURRENT_TIMESTAMP)`可以兼容`mysql`和`sqlite`，相关[issue](https://github.com/sqlalchemy/alembic/issues/634)，以及报错：
```
> alembic upgrade heads
INFO  [alembic.runtime.migration] Context impl SQLiteImpl.
INFO  [alembic.runtime.migration] Will assume non-transactional DDL.
INFO  [alembic.runtime.migration] Running upgrade  -> 9e9a36470cd5, init
INFO  [alembic.runtime.migration] Running upgrade 9e9a36470cd5 -> ddcfba3c7d5c, v4
INFO  [alembic.runtime.migration] Running upgrade ddcfba3c7d5c -> a1c10da5704b, devices
INFO  [alembic.runtime.migration] Running upgrade a1c10da5704b -> 1df05b897d3f, tasks
Traceback (most recent call last):
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1969, in _exec_single_context
    self.dialect.do_execute(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 922, in do_execute
    cursor.execute(statement, parameters)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/dialects/sqlite/aiosqlite.py", line 146, in execute
    self._adapt_connection._handle_exception(error)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/dialects/sqlite/aiosqlite.py", line 298, in _handle_exception
    raise error
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/dialects/sqlite/aiosqlite.py", line 128, in execute
    self.await_(_cursor.execute(operation, parameters))
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 125, in await_only
    return current.driver.switch(awaitable)  # type: ignore[no-any-return]
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 185, in greenlet_spawn
    value = await result
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/cursor.py", line 48, in execute
    await self._execute(self._cursor.execute, sql, parameters)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/cursor.py", line 40, in _execute
    return await self._conn._execute(fn, *args, **kwargs)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/core.py", line 133, in _execute
    return await future
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/core.py", line 106, in run
    result = function()
sqlite3.OperationalError: near "(": syntax error

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/bin/alembic", line 8, in <module>
    sys.exit(main())
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/config.py", line 630, in main
    CommandLine(prog=prog).main(argv=argv)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/config.py", line 624, in main
    self.run_cmd(cfg, options)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/config.py", line 601, in run_cmd
    fn(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/command.py", line 398, in upgrade
    script.run_env()
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/script/base.py", line 579, in run_env
    util.load_python_file(self.dir, "env.py")
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/util/pyfiles.py", line 93, in load_python_file
    module = load_module_py(module_id, path)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/util/pyfiles.py", line 109, in load_module_py
    spec.loader.exec_module(module)  # type: ignore
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/lei/workspace/forked/PaiGram/alembic/env.py", line 134, in <module>
    asyncio.run(run_migrations_online())
  File "/home/lei/.pyenv/versions/3.10.6/lib/python3.10/asyncio/runners.py", line 44, in run
    return loop.run_until_complete(main)
  File "/home/lei/.pyenv/versions/3.10.6/lib/python3.10/asyncio/base_events.py", line 646, in run_until_complete
    return future.result()
  File "/home/lei/workspace/forked/PaiGram/alembic/env.py", line 126, in run_migrations_online
    await connection.run_sync(do_run_migrations)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/ext/asyncio/engine.py", line 886, in run_sync
    return await greenlet_spawn(fn, self._proxied, *arg, **kw)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 192, in greenlet_spawn
    result = context.switch(value)
  File "/home/lei/workspace/forked/PaiGram/alembic/env.py", line 106, in do_run_migrations
    context.run_migrations()
  File "<string>", line 8, in run_migrations
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/runtime/environment.py", line 938, in run_migrations
    self.get_context().run_migrations(**kw)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/runtime/migration.py", line 624, in run_migrations
    step.migration_fn(**kw)
  File "/home/lei/workspace/forked/PaiGram/alembic/versions/1df05b897d3f_tasks.py", line 28, in upgrade
    task_table = op.create_table(
  File "<string>", line 8, in create_table
  File "<string>", line 3, in create_table
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/operations/ops.py", line 1303, in create_table
    return operations.invoke(op)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/operations/base.py", line 393, in invoke
    return fn(self, operation)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/operations/toimpl.py", line 128, in create_table
    operations.impl.create_table(table)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/ddl/impl.py", line 359, in create_table
    self._exec(schema.CreateTable(table))
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/alembic/ddl/impl.py", line 200, in _exec
    return conn.execute(construct, multiparams)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1416, in execute
    return meth(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/sql/ddl.py", line 181, in _execute_on_connection
    return connection._execute_ddl(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1528, in _execute_ddl
    ret = self._execute_context(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1848, in _execute_context
    return self._exec_single_context(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1988, in _exec_single_context
    self._handle_dbapi_exception(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 2343, in _handle_dbapi_exception
    raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/base.py", line 1969, in _exec_single_context
    self.dialect.do_execute(
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/engine/default.py", line 922, in do_execute
    cursor.execute(statement, parameters)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/dialects/sqlite/aiosqlite.py", line 146, in execute
    self._adapt_connection._handle_exception(error)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/dialects/sqlite/aiosqlite.py", line 298, in _handle_exception
    raise error
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/dialects/sqlite/aiosqlite.py", line 128, in execute
    self.await_(_cursor.execute(operation, parameters))
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 125, in await_only
    return current.driver.switch(awaitable)  # type: ignore[no-any-return]
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/sqlalchemy/util/_concurrency_py3k.py", line 185, in greenlet_spawn
    value = await result
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/cursor.py", line 48, in execute
    await self._execute(self._cursor.execute, sql, parameters)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/cursor.py", line 40, in _execute
    return await self._conn._execute(fn, *args, **kwargs)
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/core.py", line 133, in _execute
    return await future
  File "/home/lei/.pyenv/versions/3.10.6/envs/PaiGram/lib/python3.10/site-packages/aiosqlite/core.py", line 106, in run
    result = function()
sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) near "(": syntax error
[SQL:
CREATE TABLE task (
	id INTEGER NOT NULL,
	user_id BIGINT,
	chat_id BIGINT,
	time_created DATETIME DEFAULT now(),
	time_updated DATETIME,
	type VARCHAR(11),
	status VARCHAR(17),
	data JSON,
	PRIMARY KEY (id)
)

]
(Background on this error at: https://sqlalche.me/e/20/e3q8)
```


## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
