### PR TITLE
🔨Fix handle CookiesCachePoolExhausted gracefully

### DIFF
--- a/plugins/account/account.py
+++ b/plugins/account/account.py
@@ -15,7 +15,7 @@ from telegram.helpers import escape_markdown
 
 from core.basemodel import RegionEnum
 from core.plugin import Plugin, conversation, handler
-from core.services.cookies.error import TooManyRequestPublicCookies
+from core.services.cookies.error import TooManyRequestPublicCookies, CookiesCachePoolExhausted
 from core.services.cookies.services import CookiesService, PublicCookiesService
 from core.services.players.models import PlayersDataBase as Player, PlayerInfoSQLModel
 from core.services.players.services import PlayersService, PlayerInfoService
@@ -136,6 +136,9 @@ class BindAccountPlugin(Plugin.Conversation):
             cookies = await self.public_cookies_service.get_cookies(user.id, region)
         except TooManyRequestPublicCookies:
             await message.reply_text("用户查询次数过多，请稍后重试", reply_markup=ReplyKeyboardRemove())
+            return ConversationHandler.END
+        except CookiesCachePoolExhausted:
+            await message.reply_text("公共Cookies池已经耗尽，请稍后重试或者绑定 cookie", reply_markup=ReplyKeyboardRemove())
             return ConversationHandler.END
         if region == RegionEnum.HYPERION:
             client = GenshinClient(cookies=cookies.data, region=Region.CHINESE)


### PR DESCRIPTION
## 描述 / Description

在Cookie池为空的时候会报`CookiesCachePoolExhausted`，这个Exception类比`TooManyRequestPublicCookies`同样也应该返回给用户

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [x] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
