### PR TITLE
🕸️Fix standard deviation is not showing correctly in dps line chart

### DIFF
--- a/plugins/genshin/gcsim/renderer.py
+++ b/plugins/genshin/gcsim/renderer.py
@@ -64,33 +64,12 @@ class GCSimResultRenderer:
         ]
         result["extra"]["damage"] = {
             "xAxis": [i * 0.5 for i in range(len(result["statistics"]["damage_buckets"]["buckets"]))],
-            "series": [
-                {
-                    "data": [bucket["mean"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
-                    "type": "line",
-                    "stack": "x",
-                    "areaStyle": {},
-                    "name": "平均伤害",
-                },
-                {
-                    "data": [bucket["min"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
-                    "type": "line",
-                    "stack": "x",
-                    "name": "最小伤害",
-                },
-                {
-                    "data": [bucket["max"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
-                    "type": "line",
-                    "stack": "x",
-                    "name": "最大伤害",
-                },
-                {
-                    "data": [bucket["sd"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
-                    "type": "line",
-                    "stack": "x",
-                    "name": "标准差",
-                },
-            ],
+            "data": {
+                "mean": [bucket["mean"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
+                "min": [bucket["min"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
+                "max": [bucket["max"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
+                "sd": [bucket["sd"] for bucket in result["statistics"]["damage_buckets"]["buckets"]],
+            },
         }
 
         return result

--- a/plugins/genshin/gcsim/runner.py
+++ b/plugins/genshin/gcsim/runner.py
@@ -10,6 +10,7 @@ from typing import Optional, Dict, List, Union, TYPE_CHECKING, Tuple, Coroutine,
 import gcsim_pypi
 from pydantic import BaseModel
 
+from gram_core.config import config
 from metadata.shortname import idToName
 from modules.apihelper.client.components.remote import Remote
 from modules.gcsim.cache import GCSimCache
@@ -171,8 +172,9 @@ class GCSimRunner:
             merged_script = GCSimConverter.merge_character_infos(script, character_infos)
         except ValueError:
             return GCSimResult(error="无法合并角色信息", user_id=user_id, uid=uid, script_key=script_key)
-        if file_id := await self.cache.get_cache(uid, hash(str(merged_script))):
-            return GCSimResult(error=None, user_id=user_id, uid=uid, script_key=script_key, file_id=file_id)
+        if not config.debug:
+            if file_id := await self.cache.get_cache(uid, hash(str(merged_script))):
+                return GCSimResult(error=None, user_id=user_id, uid=uid, script_key=script_key, file_id=file_id)
         await self.player_gcsim_scripts.write_script(uid, script_key, str(merged_script))
         limit = _get_limit_command()
         command = [

--- a/resources/genshin/gcsim/result.jinja2
+++ b/resources/genshin/gcsim/result.jinja2
@@ -71,7 +71,6 @@
             animation: false
         });
         var damageOvertime = echarts.init(document.getElementById('damage_overtime'));
-        console.log(data["damage"]["data"]["mean"].map((mean, idx) => [mean, mean - data["damage"]["data"]["sd"][idx], mean + data["damage"]["data"]["sd"][idx]]))
         damageOvertime.setOption({
             xAxis: {
                 data: data["damage"]["xAxis"],

--- a/resources/genshin/gcsim/result.jinja2
+++ b/resources/genshin/gcsim/result.jinja2
@@ -1,101 +1,164 @@
 <!DOCTYPE html>
 <html lang="zh-CN">
+
 <head>
-    <meta charset="utf-8"/>
+    <meta charset="utf-8" />
     <title>Title</title>
     <script src="../../js/tailwindcss-3.1.8.js"></script>
     <script src="../../js/echarts.min.js"></script>
-    <link type="text/css" href="../../styles/public.css" rel="stylesheet"/>
+    <link type="text/css" href="../../styles/public.css" rel="stylesheet" />
 
 </head>
+
 <body>
-<div class="mx-auto flex w-[48rem] flex-col space-y-2 bg-gray-400 px-2 py-2">
-    <!-- START TEAM/DPS summary row -->
-    <div class="flex h-auto flex-col items-start justify-center space-y-4 rounded-lg bg-slate-600 py-6">
-        <!-- START character row -->
-        {% include "genshin/gcsim/characters.jinja2" %}
-        <!-- END character row -->
-        <!-- START summary DPS row -->
-        {% include "genshin/gcsim/summary.jinja2" %}
-        <!-- END summary DPS row -->
-    </div>
-    <!-- END TEAM/DPS summary row -->
-    <!-- START DPS distribution row -->
-    <div class="flex flex-row items-start justify-center space-x-2 rounded-lg">
-        <div class="flex h-56 w-1/2 items-center justify-center rounded-xl bg-slate-600" id="dps_by_character">
+    <div class="mx-auto flex w-[48rem] flex-col space-y-2 bg-gray-400 px-2 py-2">
+        <!-- START TEAM/DPS summary row -->
+        <div class="flex h-auto flex-col items-start justify-center space-y-4 rounded-lg bg-slate-600 py-6">
+            <!-- START character row -->
+            {% include "genshin/gcsim/characters.jinja2" %}
+            <!-- END character row -->
+            <!-- START summary DPS row -->
+            {% include "genshin/gcsim/summary.jinja2" %}
+            <!-- END summary DPS row -->
         </div>
-        <div class="flex h-56 w-1/2 items-center justify-center rounded-xl bg-slate-600" id="dps_by_element">
+        <!-- END TEAM/DPS summary row -->
+        <!-- START DPS distribution row -->
+        <div class="flex flex-row items-start justify-center space-x-2 rounded-lg">
+            <div class="flex h-56 w-1/2 items-center justify-center rounded-xl bg-slate-600" id="dps_by_character">
+            </div>
+            <div class="flex h-56 w-1/2 items-center justify-center rounded-xl bg-slate-600" id="dps_by_element">
+            </div>
         </div>
-        <script type="text/javascript">
-            var data = JSON.parse('{{ extra | tojson }}')
-            // Initialize the echarts instance based on the prepared dom
-            var dpsByCharacter = echarts.init(document.getElementById('dps_by_character'));
-            var dpsByElement = echarts.init(document.getElementById('dps_by_element'));
-            dpsByCharacter.setOption({
-                series: [
-                    {
-                        type: 'pie',
-                        data: data["character_dps"],
-                        label: {
-                            color: 'white'
-                        }
-                    }
-                ],
-                animation: false
-            });
-            dpsByElement.setOption({
-                series: [
-                    {
-                        type: 'pie',
-                        data: data["element_dps"],
-                        label: {
-                            color: 'white'
-                        }
-                    }
-                ],
-                animation: false
-            });
-        </script>
-    </div>
-    <!-- END DPS distribution row -->
-    <!-- START Energy/Heal/Shield row -->
-    <div class="flex flex-row items-start justify-center space-x-2 rounded-lg">
-        {% include "genshin/gcsim/other_summary.jinja2" %}
+        <!-- END DPS distribution row -->
+        <!-- START Energy/Heal/Shield row -->
+        <div class="flex flex-row items-start justify-center space-x-2 rounded-lg">
+            {% include "genshin/gcsim/other_summary.jinja2" %}
 
-    </div>
-    <!-- END Energy/Heal/Shield row -->
-    <!-- START DPS line chart row -->
-    <div class="flex h-80 w-full flex-row items-start justify-center rounded-lg bg-slate-600" id="damage_overtime">
-
+        </div>
+        <!-- END Energy/Heal/Shield row -->
+        <!-- START DPS line chart row -->
+        <div class="flex h-80 w-full flex-row items-start justify-center rounded-lg bg-slate-600" id="damage_overtime">
+        </div>
+        <!-- END DPS line chart row -->
     </div>
     <script type="text/javascript">
         var data = JSON.parse('{{ extra | tojson }}')
         // Initialize the echarts instance based on the prepared dom
+        var dpsByCharacter = echarts.init(document.getElementById('dps_by_character'));
+        dpsByCharacter.setOption({
+            series: [
+                {
+                    type: 'pie',
+                    data: data["character_dps"],
+                    label: {
+                        color: 'white'
+                    }
+                }
+            ],
+            animation: false
+        });
+        var dpsByElement = echarts.init(document.getElementById('dps_by_element'));
+        dpsByElement.setOption({
+            series: [
+                {
+                    type: 'pie',
+                    data: data["element_dps"],
+                    label: {
+                        color: 'white'
+                    }
+                }
+            ],
+            animation: false
+        });
         var damageOvertime = echarts.init(document.getElementById('damage_overtime'));
+        console.log(data["damage"]["data"]["mean"].map((mean, idx) => [mean, mean - data["damage"]["data"]["sd"][idx], mean + data["damage"]["data"]["sd"][idx]]))
         damageOvertime.setOption({
             xAxis: {
                 data: data["damage"]["xAxis"],
                 axisLabel: {
                     color: 'white',
+                    interval: 19
+                },
+                axisTick: {
+                    interval: 19
                 }
             },
             yAxis: {
                 axisLabel: {
-                    color: 'white'
+                    color: 'white',
+                    formatter: function (value, index) {
+                        return value / 10000 + "万";
+                    }
                 }
+            },
+            grid: {
+                left: '3%',
+                right: '3%',
+                bottom: '3%',
+                containLabel: true
             },
             legend: {
                 textStyle: {
                     color: 'white'
-                }
+                },
             },
-            series: data["damage"]["series"],
+            series: [
+                {
+                    data: data["damage"]["data"]["mean"],
+                    type: "line",
+                    lineStyle: {
+                    },
+                    showSymbol: false,
+                    name: "平均伤害",
+                },
+                {
+                    data: data["damage"]["data"]["min"],
+                    type: "line",
+                    lineStyle: {
+                        opacity: 0.5,
+                    },
+                    showSymbol: false,
+                    name: "最小伤害",
+                },
+                {
+                    data: data["damage"]["data"]["max"],
+                    type: "line",
+                    lineStyle: {
+                        opacity: 0.5,
+                    },
+                    showSymbol: false,
+                    name: "最大伤害",
+                },
+                {
+                    type: "line",
+                    data: data["damage"]["data"]["mean"].map((mean, idx) => mean + data["damage"]["data"]["sd"][idx] - (mean - data["damage"]["data"]["sd"][idx] < 0 ? 0 : mean - data["damage"]["data"]["sd"][idx])),
+                    stack: 'confidence-band',
+                    stackStrategy: 'positive',
+                    lineStyle: {
+                        opacity: 0
+                    },
+                    symbol: 'none',
+                },
+                {
+                    type: "line",
+                    data: data["damage"]["data"]["mean"].map((mean, idx) => mean - data["damage"]["data"]["sd"][idx] < 0 ? 0 : mean - data["damage"]["data"]["sd"][idx]),
+                    stack: 'confidence-band',
+                    stackStrategy: 'positive',
+                    lineStyle: {
+                        opacity: 0
+                    },
+                    areaStyle: {
+                        opacity: 0.18,
+                        color: '#4c9bd4'
+                    },
+                    symbol: 'none',
+                },
+            ],
             animation: false
         });
     </script>
-    <!-- END DPS line chart row -->
-</div>
 
 
 </body>
+
 </html>

--- a/resources/genshin/gcsim/result.jinja2
+++ b/resources/genshin/gcsim/result.jinja2
@@ -130,7 +130,7 @@
                 },
                 {
                     type: "line",
-                    data: data["damage"]["data"]["mean"].map((mean, idx) => mean + data["damage"]["data"]["sd"][idx] - (mean - data["damage"]["data"]["sd"][idx] < 0 ? 0 : mean - data["damage"]["data"]["sd"][idx])),
+                    data: data["damage"]["data"]["mean"].map((mean, idx) => mean - data["damage"]["data"]["sd"][idx] < 0 ? mean + data["damage"]["data"]["sd"][idx] : 2 * data["damage"]["data"]["sd"][idx]),
                     stack: 'confidence-band',
                     stackStrategy: 'positive',
                     lineStyle: {


### PR DESCRIPTION
## 描述 / Description

```
DPS标准差的显示有错误，同时还把X/Y轴的标签稍微整理了下
```
before             |  after
:-------------------------:|:-------------------------:
![photo_2023-12-04 22 29 47](https://github.com/PaiGramTeam/PaiGram/assets/3712421/6a5d109f-30de-4a7f-9bd1-65ce4d1c2e4b)  |  ![photo_2023-12-04 22 29 09](https://github.com/PaiGramTeam/PaiGram/assets/3712421/c95c6079-bd3f-4f12-a453-d30926228ecd)



## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
