### PR TITLE
:bug: Skip exception when dailynote has no data

### DIFF
--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -520,7 +520,10 @@ class DailyMaterial(Plugin):
         honey_item = HONEY_DATA[item_type].get(item_id)
         if honey_item is None:
             return None
-        icon = await getattr(self.assets_service, item_type)(item_id).icon()
+        try:
+            icon = await getattr(self.assets_service, item_type)(item_id).icon()
+        except KeyError:
+            return None
         return ItemData(
             id=item_id,
             name=typing.cast(str, honey_item[1]),


### PR DESCRIPTION
## 描述 / Description

Honey Impact 更新数据但是头像信息没更新时，暂时跳过该武器、角色，否则会导致当日 `/daily_material` 无法输出。

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
