### PR TITLE
:bug: Get get item id from data-assign in daily_material

### DIFF
--- a/metadata/scripts/honey.py
+++ b/metadata/scripts/honey.py
@@ -55,6 +55,8 @@ async def get_avatar_data() -> DATA_TYPE:
         cid = int("10000" + re.findall(r"\d+", data[1])[0])
         honey_id = re.findall(r"/(.*?)/", data[1])[0]
         name = re.findall(r">(.*)<", data[1])[0]
+        if "测试" in name:
+            continue
         rarity = int(re.findall(r">(\d)<", data[2])[0])
         result[cid] = [honey_id, name, rarity]
     return result

--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -673,10 +673,10 @@ def _parse_honey_impact_source(source: bytes) -> MaterialsData:
             item_name_span = calendar_pic_wrap.select_one("span")
             if item_name_span is None or item_name_span.text.strip() == "旅行者":
                 continue  # 因为旅行者的天赋计算比较复杂，不做旅行者的天赋计算
-            href = element.attrs["href"]  # Item ID 在 href 中
-            item_is_weapon = href.startswith("/i_n")
-            # 角色 ID 前缀固定 10000，但是 honey impact 替换成了角色名，剩余部分的数字是真正的 Item ID 组成部分
-            item_id = f"{'' if item_is_weapon else '10000'}{''.join(filter(str.isdigit, href))}"
+            # data-assign 的数字就是 Item ID
+            data_assign = calendar_pic_wrap.attrs["data-assign"]
+            item_is_weapon = data_assign.startswith("weapon_")
+            item_id = "".join(filter(str.isdigit, data_assign))
             for weekday in map(int, calendar_pic_wrap.attrs["data-days"]):  # data-days 中存的是星期几可以刷素材
                 ascendable_items = everyday_materials[weekday][current_country]
                 ascendable_items = ascendable_items.weapon if item_is_weapon else ascendable_items.avatar


### PR DESCRIPTION
## 描述 / Description

上游测试数据导致一个假设被破坏，修正一下逻辑。

honeyhunterworld 出现了测试角色 1100046 火神(测试)。

由于此前一直用 item_id 后三位作为角色的 item_id，导致和胡桃的 1000046 冲突，会出现
1. 拥有胡桃的用户，胡桃在周三、周六出现在蒙德可练角色中；
2. 未拥有胡桃的用户，胡桃会在周二、周五名字变成火神(测试)。