### PR TITLE
:bug: API `.[].weapon.type` Uses Chinese

### DIFF
--- a/plugins/genshin/avatar_list.py
+++ b/plugins/genshin/avatar_list.py
@@ -228,7 +228,7 @@ class AvatarListPlugin(Plugin):
                 filter_element_names = {element.name for element in filter_elements}
                 characters = [c for c in characters if c.element in filter_element_names]
             if filter_weapon_types:
-                filter_weapon_type_names = {weapon_types.name for weapon_types in filter_weapon_types}
+                filter_weapon_type_names = {weapon_types.value for weapon_types in filter_weapon_types}
                 characters = [c for c in characters if c.weapon.type in filter_weapon_type_names]
             if not characters:
                 reply_message = await message.reply_text("没有符合条件的角色")


### PR DESCRIPTION
## 描述 / Description

`/avatars` 命令所使用的 `get_genshin_character_detail` API，其返回的数据中 `.[].weapon.type` 是中文的 `"长柄武器"`、`"单手剑"` 等字符串，因此用 `WeaponType.value` 字段来匹配，`WeaponType.name` 会匹配失败返回空列表。