### PR TITLE
:zap: Improve `get_material_serial_name` Performance

### DIFF
--- a/plugins/genshin/daily/material.py
+++ b/plugins/genshin/daily/material.py
@@ -1,9 +1,9 @@
 import asyncio
+import functools
 import typing
 from datetime import datetime, timedelta
-from typing import TYPE_CHECKING, Dict, Iterable, Iterator, List, Optional, Tuple
+from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple
 
-from arkowrapper import ArkoWrapper
 from httpx import AsyncClient
 from pydantic import BaseModel
 from simnet.errors import BadRequest as SimnetBadRequest
@@ -53,31 +53,46 @@ def sort_item(items: List["ItemData"]) -> Iterable["ItemData"]:
     return sorted(items, key=key, reverse=True)
 
 
+# 因为直接贪心了，所以结果是错误的（别笑，之前的实现也是错的，甚至更慢）
+# 虽然是错的，但是在这个场景下是对的，因为目前原神的材料名里没有多个长度大于 1 的子串
+# 正确的实现是后缀树
+#
+# 旧代码错误样例: get_material_serial_name(["abc.xyz", "abc.xyz", "x", "x"]) -> "abc.xyz"，正确答案是 "x"
+#
+# 错误样例: longest_common_substring("abc.wxyz", "abc@wxyz", "abc#yz") -> "yz", 正确答案是 "abc"
+def longest_common_substring(*name: str) -> str:
+    """
+    求第一个最长公共子序列
+
+    最差时间复杂度是 O(字符串长度² * 字符串数量)
+    空间复杂度固定是 O(最短字符串的长度)
+    """
+
+    def lcs_two(lstr: str, rstr: str) -> str:
+        memo = [[0 for _ in lstr] for _ in range(2)]
+        lcs = ""
+        for i, rchar in enumerate(rstr):
+            for j, lchar in enumerate(lstr):
+                if lchar != rchar:
+                    memo[i & 1][j] = 0
+                    continue
+                memo[i & 1][j] = memo[i & 1 ^ 1][j - 1] + 1 if i != 0 and j != 0 else 1
+                if memo[i & 1][j] > len(lcs):
+                    lcs_len = memo[i & 1][j]
+                    lcs = lstr[j - lcs_len + 1 : j + 1]
+        return lcs
+
+    # 先求短的最长公共子序列的，复杂度会稍微低一点
+    return functools.reduce(lcs_two, sorted(name, key=len))
+
+
 def get_material_serial_name(names: Iterable[str]) -> str:
     """
-    获取材料的系列名，本质上是求字符串列表的最长子串
+    获取材料的系列名，求最长公共子串后删除前后缀的「的」和「之」
     如：「自由」的教导、「自由」的指引、「自由」的哲学，三者系列名为「『自由』」
     如：高塔孤王的破瓦、高塔孤王的残垣、高塔孤王的断片、高塔孤王的碎梦，四者系列名为「高塔孤王」
-    TODO(xr1s): 感觉可以优化
     """
-
-    def all_substrings(string: str) -> Iterator[str]:
-        """获取字符串的所有连续字串"""
-        length = len(string)
-        for i in range(length):
-            for j in range(i + 1, length + 1):
-                yield string[i:j]
-
-    result = []
-    for name_a, name_b in ArkoWrapper(names).repeat(1).group(2).unique(list):
-        for sub_string in all_substrings(name_a):
-            if sub_string in ArkoWrapper(all_substrings(name_b)):
-                result.append(sub_string)
-    result = ArkoWrapper(result).sort(len, reverse=True)[0]
-    chars = {"的": 0, "之": 0}
-    for char, k in chars.items():
-        result = result.split(char)[k]
-    return result
+    return longest_common_substring(*names).strip("的之")
 
 
 def is_first_week_of_pool(date: Optional["datetime"] = None) -> bool:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ license = {text = "AGPL-3.0"}
 
 [project.optional-dependencies]
 pyro = ["PyroTgCrypto<2.0.0,>=1.2.7", "Pyrogram @ git+https://github.com/TeamPGM/pyrogram"]
-test = ["pytest<9.0.0,>=8.2.2", "pytest-asyncio<1.0.0,>=0.24.0", "flaky<4.0.0,>=3.7.0"]
+test = ["pytest<9.0.0,>=8.2.2", "pytest-asyncio<1.0.0,>=0.24.0", "pytest-benchmark<6.0.0,>=5.2.3", "flaky<4.0.0,>=3.7.0"]
 genshin-artifact = ["python-genshin-artifact<2.0.0,>=1.0.9"]
 
 [tool.pytest.ini_options]

--- a/tests/bench/test_get_material_serial_name.py
+++ b/tests/bench/test_get_material_serial_name.py
@@ -1,0 +1,63 @@
+from collections.abc import Iterable, Iterator
+
+import pytest_benchmark.fixture
+from arkowrapper import ArkoWrapper
+
+import plugins.genshin.daily.material
+
+
+# Old implementation
+def get_material_serial_name(names: Iterable[str]) -> str:
+    """
+    获取材料的系列名，本质上是求字符串列表的最长子串
+    如：「自由」的教导、「自由」的指引、「自由」的哲学，三者系列名为「『自由』」
+    如：高塔孤王的破瓦、高塔孤王的残垣、高塔孤王的断片、高塔孤王的碎梦，四者系列名为「高塔孤王」
+    TODO(xr1s): 感觉可以优化
+    """
+
+    def all_substrings(string: str) -> Iterator[str]:
+        """获取字符串的所有连续字串"""
+        length = len(string)
+        for i in range(length):
+            for j in range(i + 1, length + 1):
+                yield string[i:j]
+
+    result = []
+    for name_a, name_b in ArkoWrapper(names).repeat(1).group(2).unique(list):
+        for sub_string in all_substrings(name_a):
+            if sub_string in ArkoWrapper(all_substrings(name_b)):
+                result.append(sub_string)
+    result = ArkoWrapper(result).sort(len, reverse=True)[0]
+    chars = {"的": 0, "之": 0}
+    for char, k in chars.items():
+        result = result.split(char)[k]
+    return result
+
+
+def test_old_get_material_serial_name_decarabian(benchmark: pytest_benchmark.fixture.BenchmarkFixture):
+    series = benchmark(
+        get_material_serial_name,
+        ["高塔孤王的破瓦", "高塔孤王的残垣", "高塔孤王的断片", "高塔孤王的碎梦"],
+    )
+    assert series == "高塔孤王"
+
+
+def test_old_get_material_serial_name_freedom(benchmark: pytest_benchmark.fixture.BenchmarkFixture):
+    series = benchmark(get_material_serial_name, ["「自由」的教导", "「自由」的指引", "「自由」的哲学"])
+    assert series == "「自由」"
+
+
+def test_new_get_material_serial_name_decarabian(benchmark: pytest_benchmark.fixture.BenchmarkFixture):
+    series = benchmark(
+        plugins.genshin.daily.material.get_material_serial_name,
+        ["高塔孤王的破瓦", "高塔孤王的残垣", "高塔孤王的断片", "高塔孤王的碎梦"],
+    )
+    assert series == "高塔孤王"
+
+
+def test_new_get_material_serial_name_freedom(benchmark: pytest_benchmark.fixture.BenchmarkFixture):
+    series = benchmark(
+        plugins.genshin.daily.material.get_material_serial_name,
+        ["「自由」的教导", "「自由」的指引", "「自由」的哲学"],
+    )
+    assert series == "「自由」"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <4.0"
 resolution-markers = [
     "python_full_version >= '3.14'",
@@ -1637,6 +1637,7 @@ test = [
     { name = "flaky" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-benchmark" },
 ]
 
 [package.dev-dependencies]
@@ -1676,6 +1677,7 @@ requires-dist = [
     { name = "pyrotgcrypto", marker = "extra == 'pyro'", specifier = ">=1.2.7,<2.0.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.2.2,<9.0.0" },
     { name = "pytest-asyncio", marker = "extra == 'test'", specifier = ">=0.24.0,<1.0.0" },
+    { name = "pytest-benchmark", marker = "extra == 'test'", specifier = ">=5.2.3,<6.0.0" },
     { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
     { name = "python-genshin-artifact", marker = "extra == 'genshin-artifact'", specifier = ">=1.0.9,<2.0.0" },
     { name = "python-telegram-bot", extras = ["ext", "rate-limiter"], specifier = ">=22.0,<23.0" },
@@ -1937,6 +1939,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
     { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
     { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
+]
+
+[[package]]
+name = "py-cpuinfo"
+version = "9.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/37/a8/d832f7293ebb21690860d2e01d8115e5ff6f2ae8bbdc953f0eb0fa4bd2c7/py-cpuinfo-9.0.0.tar.gz", hash = "sha256:3cdbbf3fac90dc6f118bfd64384f309edeadd902d7c8fb17f02ffa1fc3f49690", size = 104716, upload-time = "2022-10-25T20:38:06.303Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/a9/023730ba63db1e494a271cb018dcd361bd2c917ba7004c3e49d5daf795a2/py_cpuinfo-9.0.0-py3-none-any.whl", hash = "sha256:859625bc251f64e21f077d099d4162689c762b5d6a4c3c97553d56241c9674d5", size = 22335, upload-time = "2022-10-25T20:38:27.636Z" },
 ]
 
 [[package]]
@@ -2234,6 +2245,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/c4/453c52c659521066969523e87d85d54139bbd17b78f09532fb8eb8cdb58e/pytest_asyncio-0.26.0.tar.gz", hash = "sha256:c4df2a697648241ff39e7f0e4a73050b03f123f760673956cf0d72a4990e312f", size = 54156, upload-time = "2025-03-25T06:22:28.883Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/20/7f/338843f449ace853647ace35870874f69a764d251872ed1b4de9f234822c/pytest_asyncio-0.26.0-py3-none-any.whl", hash = "sha256:7b51ed894f4fbea1340262bdae5135797ebbe21d8638978e35d31c6d19f72fb0", size = 19694, upload-time = "2025-03-25T06:22:27.807Z" },
+]
+
+[[package]]
+name = "pytest-benchmark"
+version = "5.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "py-cpuinfo" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/24/34/9f732b76456d64faffbef6232f1f9dbec7a7c4999ff46282fa418bd1af66/pytest_benchmark-5.2.3.tar.gz", hash = "sha256:deb7317998a23c650fd4ff76e1230066a76cb45dcece0aca5607143c619e7779", size = 341340, upload-time = "2025-11-09T18:48:43.215Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/29/e756e715a48959f1c0045342088d7ca9762a2f509b945f362a316e9412b7/pytest_benchmark-5.2.3-py3-none-any.whl", hash = "sha256:bc839726ad20e99aaa0d11a127445457b4219bdb9e80a1afc4b51da7f96b0803", size = 45255, upload-time = "2025-11-09T18:48:39.765Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 该 PR 相关 Issue / Involved issue

Close #

## 描述 / Description

使用更高效的算法替换了最长公共子序列的计算。

```
----------------------------------------------------------------------------------------------------- benchmark: 4 tests ----------------------------------------------------------------------------------------------------
Name (time in us)                                     Min                   Max                Mean             StdDev              Median                IQR            Outliers  OPS (Kops/s)            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_new_get_material_serial_name_freedom         10.4000 (1.0)        202.9000 (1.14)      11.6026 (1.0)       4.3362 (1.0)       10.8000 (1.0)       1.0000 (1.0)     1457;2233       86.1877 (1.0)       59524           1
test_new_get_material_serial_name_decarabian      15.0000 (1.44)       178.6000 (1.0)       16.9001 (1.46)      4.6148 (1.06)      16.6000 (1.54)      1.9000 (1.90)      855;922       59.1712 (0.69)      34247           1
test_old_get_material_serial_name_decarabian     511.1000 (49.14)    1,019.5000 (5.71)     593.7257 (51.17)    44.6877 (10.31)    587.7000 (54.42)    28.3000 (28.30)      121;93        1.6843 (0.02)        794           1
test_old_get_material_serial_name_freedom        648.9000 (62.39)    1,713.3000 (9.59)     758.5552 (65.38)    74.9158 (17.28)    750.4000 (69.48)    31.5000 (31.50)     152;177        1.3183 (0.02)       1316           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
```

## 更改检查表 / Change Checklist
  
- [ ] 有插件命令更新
  - [ ] 已更新 bot 帮助文件
- [ ] 有流程交互
  - [ ] 指引明确
  - [ ] 可以退出
- [ ] 会触发频率限制
  - [ ] 有对应的限制措施
- [ ] 需要用户输入数据
  - [ ] 验证用户数据
  - [ ] 如果是文件，检查了文件大小
  - [ ] 对保存的数据再次进行了验证
- [ ] 添加了新的依赖包
- [ ] 测试
  - [ ] 本地通过了测试
  - [ ] CI 通过了测试

## 说明 / Note
